### PR TITLE
Quick patch for question bank re-import issue.

### DIFF
--- a/questiontype.php
+++ b/questiontype.php
@@ -77,7 +77,14 @@ class qtype_knowledgecheck extends question_type {
             $options->id = $DB->insert_record('qtype_knowledgecheck_options', $options);
         }
 
-        $options->responsetemplate = $question->responsetemplate['text'];
+        if (is_string($question->responsetemplate)) {
+            // Band-aid solution for question-bank import/export misalignment.
+            // @link https://github.com/ucsf-education/knowledgecheck/issues/18.
+            // TODO: correct the misalignment on the export-side of things [ST 2025/04/04].
+            $options->responsetemplate = $question->responsetemplate;
+        } else {
+            $options->responsetemplate = $question->responsetemplate['text'];
+        }
         $DB->update_record('qtype_knowledgecheck_options', $options);
         $this->save_question_answers($question);
         $this->save_hints($question);

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'qtype_knowledgecheck';
-$plugin->version = 2024092700;
+$plugin->version = 2024092701;
 $plugin->release = 'v4.4';
 $plugin->requires = 2024041600;
 $plugin->supported = [404, 404];


### PR DESCRIPTION
the `save_question_options()` function is called from the UI when saving a question, and during the question-bank import process.

the data structure of the `responsetemplate` attribute is different between these two workflows.

the correct data structure is an assoc array, which is what the UI provides on save. the import process gives us a string here however, which was unexpected, resulting in an "Cannot access offset of type string on string" type error.

adding a type check here and dealing with the variation this way is a stop-gap solution until this can be corrected on the export-side of things.

refs #18 
